### PR TITLE
CI: add pre-commit and modernize tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov
+          pip install pytest pytest-asyncio pytest-cov pre-commit
+
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files
 
       - name: Lint with ruff
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions tests workflow to install `pre-commit` and run `pre-commit run --all-files` as part of CI. It also keeps the existing Ruff lint and unit test steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the continuous integration testing pipeline with additional automated code quality checks executed before existing validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->