### PR TITLE
Docs: add issue templates, PR template, and contribution/security docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Report a bug in the Ecotracker Home Assistant integration
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an improvement or new feature for the Ecotracker integration
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- Describe the change and why it is needed -->
+
+## Changes
+
+- 
+
+## Checklist
+
+- [ ] I have tested the change locally
+- [ ] I updated the documentation if needed
+- [ ] I have added tests for new features or bug fixes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming community, we pledge to make participation in this project a harassment-free experience.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying standards and enforcing the code of conduct.
+
+## Reporting Guidelines
+
+Instances of abusive, harassing, or otherwise unacceptable behavior should be reported to the repository maintainers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,6 @@ Install the project dependencies:
 ```bash
 python -m pip install --upgrade pip
 pip install -r requirements.txt
-pip install pytest pytest-asyncio pytest-cov pre-commit
 ```
 
 Run formatting and linting:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Ecotracker
+
+Thank you for your interest in contributing to the Ecotracker Home Assistant integration.
+
+## Getting started
+
+1. Fork the repository.
+2. Create a feature branch from `main`.
+3. Make your changes.
+4. Run the test suite and formatter.
+5. Open a pull request with a clear description.
+
+## Development setup
+
+Install the project dependencies:
+
+```bash
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install pytest pytest-asyncio pytest-cov pre-commit
+```
+
+Run formatting and linting:
+
+```bash
+pre-commit run --all-files
+```
+
+Run tests:
+
+```bash
+pytest tests/unit/ -v
+```
+
+## Code style
+
+This repository uses `ruff` and `pre-commit` for formatting and linting.
+
+## Pull request process
+
+- Use clear branch names.
+- Keep PRs small and focused.
+- Include tests for bug fixes and new features.
+- Use the provided PR template.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+If you discover a security vulnerability in Ecotracker, please report it responsibly.
+
+- Email: stefanseeger@users.noreply.github.com
+- Do not create a public issue for security vulnerabilities.
+
+We will acknowledge receipt and respond as quickly as possible.


### PR DESCRIPTION
Add GitHub issue templates, a pull request template, and repository guidance files for contributing, security reporting, and code of conduct.